### PR TITLE
fix(iam_policy_project): set RegionType=Global to use the global IAM endpoint

### DIFF
--- a/volcengine/iam/iam_policy_project/service_volcengine_iam_policy_project.go
+++ b/volcengine/iam/iam_policy_project/service_volcengine_iam_policy_project.go
@@ -189,6 +189,7 @@ func (s *VolcengineIamPolicyProjectService) ReadResource(d *schema.ResourceData,
 		Action:      action,
 		Version:     "2018-01-01",
 		HttpMethod:  ve.GET,
+		RegionType:  ve.Global,
 	}, &param)
 	if err != nil {
 		if strings.Contains(err.Error(), "NotExist") {


### PR DESCRIPTION
## Summary

The `ReadResource` for `volcengine_iam_policy_project` (added in v0.0.189) omits `RegionType`, so it falls through to `RegionType: Regional` (zero value of the `iota`-based enum). The Universal client then routes the call to a regional IAM endpoint (e.g. `iam.cn-shanghai.volcengineapi.com`) instead of the global one (`iam.volcengineapi.com`).

In practice every Read fails with the cryptic transport error:

```
Error: error on reading resource "UserGroup:<group>:System:<policy>:<project>",
RequestError: send request failed
```

Every read errors → every plan errors → resource is unusable. This blocks importing existing project-scoped attachments and prevents drift detection on managed ones.

## Reproduction

```hcl
terraform {
  required_providers {
    volcengine = {
      source  = "volcengine/volcengine"
      version = "0.0.196"
    }
  }
}

provider "volcengine" {
  region = "cn-shanghai"
}

# An existing project-scoped UserGroup policy attachment.
import {
  to = volcengine_iam_policy_project.example
  id = "UserGroup:my_group:System:ArkFullAccess:my_project"
}

resource "volcengine_iam_policy_project" "example" {
  principal_type = "UserGroup"
  principal_name = "my_group"
  policy_type    = "System"
  policy_name    = "ArkFullAccess"
  project_names  = ["my_project"]
}
```

`terraform plan` returns:

```
Error: error on reading resource "UserGroup:my_group:System:ArkFullAccess:my_project", RequestError: send request failed
```

## Fix

One line — add `RegionType: ve.Global` to the inline `UniversalInfo`. After the patch the same plan succeeds with `0 to add, 0 to change, 0 to destroy` and the resource is correctly imported.

Every other IAM resource in this provider that calls `ListAttachedUserGroupPolicies` (e.g. `iam_user_group_policy_attachment`'s `getUniversalInfo` helper) already sets `RegionType: ve.Global` — this fix just brings `iam_policy_project` in line with the rest.

## Test plan

- [x] Built locally and ran `terraform plan` against a real Volcengine account in `cn-shanghai` with 15 existing project-scoped UserGroup attachments.
- [x] Without the patch: 15 reads, all fail with `RequestError: send request failed`.
- [x] With the patch: 15 reads succeed, plan reports `0 to add, 0 to change, 0 to destroy`.